### PR TITLE
[MINOR] - Set native issue type in raise-feature and raise-bug

### DIFF
--- a/skills/git/create-pr-gh/scripts/create-pr-gh-helper.py
+++ b/skills/git/create-pr-gh/scripts/create-pr-gh-helper.py
@@ -134,13 +134,15 @@ def apply(t, plan_path, dry):
     if not template: raise SkillError('Shared pull request template not found: .github/.github/PULL_REQUEST_TEMPLATE/pull-request.md')
     plan=load_plan(plan_path); require_approved(plan); gh=exe('gh'); repo=plan.get('repository') or parse_github(remote_origin(p)); base=plan.get('base')
     if not gh or not repo: raise SkillError('gh and repository are required')
+    head=(git(p,'branch','--show-current').stdout.strip() if git_root(p) else '')
+    if not head: raise SkillError('Could not determine the current branch in --target to use as the PR head')
     title=plan.get('title'); body=plan.get('body')
     if not isinstance(title,str) or not isinstance(body,str): raise SkillError('title and body are required')
     if not base:
-        cp=run([gh,'api',f'repos/{repo}','--jq','.default_branch'],check=True); base=cp.stdout.strip()
-    cmd=[gh,'pr','create','--repo',repo,'--base',base,'--title',title,'--body',body]
+        cp=run([gh,'api',f'repos/{repo}','--jq','.default_branch'],check=True,cwd=p); base=cp.stdout.strip()
+    cmd=[gh,'pr','create','--repo',repo,'--head',head,'--base',base,'--title',title,'--body',body]
     if dry: return {'dry_run':True,'would_run':cmd[1:]}
-    cp=run(cmd,check=True); return {'created_pr_url':cp.stdout.strip().splitlines()[-1]}
+    cp=run(cmd,check=True,cwd=p); return {'created_pr_url':cp.stdout.strip().splitlines()[-1]}
 
 def main(argv=None):
     ap=argparse.ArgumentParser(); sub=ap.add_subparsers(dest='cmd',required=True); i=sub.add_parser('inspect'); i.add_argument('--target',required=True); i.add_argument('--json',action='store_true'); a=sub.add_parser('apply'); a.add_argument('--target',required=True); a.add_argument('--plan',required=True); a.add_argument('--dry-run',action='store_true'); ns=ap.parse_args(argv)

--- a/skills/github/raise-bug/SKILL.md
+++ b/skills/github/raise-bug/SKILL.md
@@ -28,7 +28,7 @@ Use the bundled Python helper for deterministic repository detection, shared iss
    }
    ```
 
-   Optional plan fields are `label` and `assignee`; defaults are `use-type-field-instead` and `liam-goodchild`. Only override `label` for exceptional repositories; normal classification belongs in the GitHub Project Type field.
+   Optional plan fields are `label` and `assignee`; defaults are `use-type-field-instead` and `liam-goodchild`. Only override `label` for exceptional repositories; classification is carried by the native GitHub issue type (set to `Bug`), not by labels.
 
 5. Dry-run, then create:
 

--- a/skills/github/raise-bug/scripts/raise-bug-helper.py
+++ b/skills/github/raise-bug/scripts/raise-bug-helper.py
@@ -62,7 +62,11 @@ def load_plan(path: str) -> dict[str, Any]:
 def require_approved(plan: dict[str, Any]):
     if plan.get('approved') is not True: raise SkillError('Plan must include approved=true after explicit user approval')
 
-BUG_PREFIX='[BUG] - '; DEFAULT_LABEL='use-type-field-instead'; DEFAULT_ASSIGNEE='liam-goodchild'; PROJECT_ID='PVT_kwHOB9ID-s4BU_KB'; TYPE_FIELD_ID='PVTSSF_lAHOB9ID-s4BU_KBzhRbk2o'; BUG_OPTION_ID='951d9251'
+# ISSUE_TYPE is the native (root-level) GitHub issue type shown on the issue
+# itself, distinct from any Project V2 board field. Must exist in the org issue-type set.
+BUG_PREFIX='[BUG] - '; DEFAULT_LABEL='use-type-field-instead'; DEFAULT_ASSIGNEE='liam-goodchild'; PROJECT_ID='PVT_kwDOEbaq0c4BcELw'; ISSUE_TYPE='Bug'
+def set_issue_type(gh, repo, num, type_name):
+    run([gh,'api','-X','PATCH',f'repos/{repo}/issues/{num}','-f',f'type={type_name}'],check=True)
 def parse_template(path: Path) -> dict[str,Any]:
     text=path.read_text(encoding='utf-8'); meta: dict[str,str]={}; body=text
     if text.startswith('---\n'):
@@ -95,7 +99,7 @@ def inspect(t):
     p=target_dir(t); gh=exe('gh'); remote=remote_origin(p); repo=parse_github(remote); auth={'ok':False,'summary':'gh not found'}
     if gh:
         cp=run([gh,'auth','status','-h','github.com']); auth={'ok':cp.returncode==0,'summary':'authenticated' if cp.returncode==0 else 'not authenticated'}
-    template=find_issue_template(p,'bug-report.md'); fm=template.get('frontmatter',{}) if template else {}; return {'target':str(p),'git_remote_origin':remote,'inferred_repository':repo,'gh_path':gh,'gh_auth':auth,'issue_template':template,'project':{'id':PROJECT_ID,'type_field_id':TYPE_FIELD_ID,'bug_option_id':BUG_OPTION_ID},'required_plan_fields':['repository','title','description','steps','expected','approved'],'defaults':{'label':DEFAULT_LABEL,'assignee':fm.get('assignees',DEFAULT_ASSIGNEE),'title_prefix':fm.get('title',BUG_PREFIX+'Placeholder')},'risk_flags':[k for k,b in {'repository_not_inferred':not repo,'gh_not_found':not gh,'gh_not_authenticated':gh and not auth['ok'],'issue_template_not_found':not template}.items() if b]}
+    template=find_issue_template(p,'bug-report.md'); fm=template.get('frontmatter',{}) if template else {}; return {'target':str(p),'git_remote_origin':remote,'inferred_repository':repo,'gh_path':gh,'gh_auth':auth,'issue_template':template,'project':{'id':PROJECT_ID,'issue_type':ISSUE_TYPE},'required_plan_fields':['repository','title','description','steps','expected','approved'],'defaults':{'label':DEFAULT_LABEL,'assignee':fm.get('assignees',DEFAULT_ASSIGNEE),'title_prefix':fm.get('title',BUG_PREFIX+'Placeholder')},'risk_flags':[k for k,b in {'repository_not_inferred':not repo,'gh_not_found':not gh,'gh_not_authenticated':gh and not auth['ok'],'issue_template_not_found':not template}.items() if b]}
 def req(plan,k):
     v=plan.get(k)
     if not isinstance(v,str) or not v.strip(): raise SkillError(f'{k} must be a non-empty string')
@@ -108,17 +112,16 @@ def apply(t, plan_path, dry):
     p=target_dir(t); plan=load_plan(plan_path); require_approved(plan); gh=exe('gh')
     if not gh: raise SkillError('gh executable not found')
     repo=req(plan,'repository'); template=find_issue_template(p,'bug-report.md'); fm=template.get('frontmatter',{}) if template else {}; title=normalize_title(req(plan,'title'),template); body=build_body(req(plan,'description'),req(plan,'steps'),req(plan,'expected'),template)
-    summary={'repository':repo,'title':title,'body_preview':body,'label':plan.get('label',DEFAULT_LABEL),'assignee':plan.get('assignee',fm.get('assignees',DEFAULT_ASSIGNEE)),'project':{'id':PROJECT_ID,'type':'Bug'}}
-    if dry: return {**summary,'dry_run':True,'would_create_issue':True,'would_set_project_type':True}
+    summary={'repository':repo,'title':title,'body_preview':body,'label':plan.get('label',DEFAULT_LABEL),'assignee':plan.get('assignee',fm.get('assignees',DEFAULT_ASSIGNEE)),'issue_type':ISSUE_TYPE,'project':{'id':PROJECT_ID}}
+    if dry: return {**summary,'dry_run':True,'would_create_issue':True,'would_set_issue_type':ISSUE_TYPE,'would_add_to_project':True}
     cp=run([gh,'issue','create','--repo',repo,'--title',title,'--label',summary['label'],'--assignee',summary['assignee'],'--body',body],check=True)
     url=cp.stdout.strip().splitlines()[-1]; m=re.search(r'/issues/(\d+)',url)
     if not m: raise SkillError(f'Could not parse issue URL: {url}')
+    set_issue_type(gh,repo,m.group(1),ISSUE_TYPE)
     node=run([gh,'api',f'repos/{repo}/issues/{m.group(1)}','--jq','.node_id'],check=True).stdout.strip()
     add='mutation($projectId: ID!, $contentId: ID!) { addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) { item { id } } }'
     item=gh_graphql(gh,add,{'projectId':PROJECT_ID,'contentId':node}).get('data',{}).get('addProjectV2ItemById',{}).get('item',{}).get('id')
-    setq='mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) { updateProjectV2ItemFieldValue(input: {projectId: $projectId, itemId: $itemId, fieldId: $fieldId, value: { singleSelectOptionId: $optionId }}) { projectV2Item { id } } }'
-    if item: gh_graphql(gh,setq,{'projectId':PROJECT_ID,'itemId':item,'fieldId':TYPE_FIELD_ID,'optionId':BUG_OPTION_ID})
-    return {**summary,'created_issue_url':url,'issue_number':m.group(1),'project_item_id':item,'project_type_set':'Bug'}
+    return {**summary,'created_issue_url':url,'issue_number':m.group(1),'project_item_id':item,'issue_type_set':ISSUE_TYPE}
 def main(argv=None):
     ap=argparse.ArgumentParser(); sub=ap.add_subparsers(dest='cmd',required=True); i=sub.add_parser('inspect'); i.add_argument('--target',required=True); i.add_argument('--json',action='store_true'); a=sub.add_parser('apply'); a.add_argument('--target',required=True); a.add_argument('--plan',required=True); a.add_argument('--dry-run',action='store_true'); ns=ap.parse_args(argv)
     try: out(inspect(ns.target) if ns.cmd=='inspect' else apply(ns.target,ns.plan,ns.dry_run)); return 0

--- a/skills/github/raise-feature/SKILL.md
+++ b/skills/github/raise-feature/SKILL.md
@@ -19,7 +19,7 @@ Inspect these JSON fields:
 - `risk_flags`: stop and resolve `repository_not_inferred`, `gh_not_found`, or `gh_not_authenticated` before applying.
 - `issue_template`: the shared template loaded from `.github/.github/ISSUE_TEMPLATE/feature-request.md`. Do not invent or use embedded issue templates.
 - `defaults`: label, assignee, and title prefix used by the helper. The helper intentionally defaults `label` to `use-type-field-instead` rather than inheriting semantic labels from the shared issue template.
-- `project`: the Sky Haven Project V2 IDs used to set Type to Feature.
+- `project`: the Sky Haven Project Board ID the issue is added to, plus the native GitHub issue type (`Feature`) the helper sets on the issue itself.
 
 ## Step 2 — Gather and draft
 
@@ -58,7 +58,7 @@ Create a plan JSON file outside the target repository, for example in `$env:TEMP
 }
 ```
 
-Optional plan fields are `label` and `assignee`; defaults are `use-type-field-instead` and `liam-goodchild`. Only override `label` for exceptional repositories; normal classification belongs in the GitHub Project Type field.
+Optional plan fields are `label` and `assignee`; defaults are `use-type-field-instead` and `liam-goodchild`. Only override `label` for exceptional repositories; classification is carried by the native GitHub issue type (set to `Feature`), not by labels.
 
 ## Step 4 — Validate or create the issue
 
@@ -74,7 +74,7 @@ After approval and validation, create the issue:
 python "C:\Local Files\Repositories\Sky Haven\ops-developer-config\skills\git\raise-feature\scripts\raise-feature-helper.py" apply --target "." --plan "$env:TEMP\feature-plan.json"
 ```
 
-The helper uses `gh issue create`, adds the created issue to the Sky Haven Project Board, and sets the **Type** field to **Feature** using option ID `c156bb04`.
+The helper uses `gh issue create`, sets the native **GitHub issue type** to **Feature** on the issue itself (root level, via the org issue-type set), and adds the created issue to the Sky Haven Project Board. It no longer writes the board's custom Type field — the issue type lives on the issue.
 
 ## Step 5 — Report back
 

--- a/skills/github/raise-feature/scripts/raise-feature-helper.py
+++ b/skills/github/raise-feature/scripts/raise-feature-helper.py
@@ -22,11 +22,12 @@ from typing import Any
 from urllib.parse import urlparse
 
 FEATURE_PREFIX = "[FEATURE] - "
+# Native, repository/organisation-level GitHub issue type (shown on the issue
+# itself), as opposed to a Project V2 board field. This is the "root level" type.
+ISSUE_TYPE = "Feature"
 DEFAULT_LABEL = "use-type-field-instead"
 DEFAULT_ASSIGNEE = "liam-goodchild"
-PROJECT_ID = "PVT_kwHOB9ID-s4BU_KB"
-TYPE_FIELD_ID = "PVTSSF_lAHOB9ID-s4BU_KBzhRbk2o"
-FEATURE_OPTION_ID = "c156bb04"
+PROJECT_ID = "PVT_kwDOEbaq0c4BcELw"
 REPO_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 ISSUE_URL_PATTERN = re.compile(r"https://github\.com/([^/]+/[^/]+)/issues/(\d+)")
 
@@ -189,8 +190,7 @@ def inspect_target(target_arg: str) -> dict[str, Any]:
         "issue_template": template,
         "project": {
             "id": PROJECT_ID,
-            "type_field_id": TYPE_FIELD_ID,
-            "feature_option_id": FEATURE_OPTION_ID,
+            "issue_type": ISSUE_TYPE,
         },
         "required_plan_fields": ["repository", "title", "problem", "solution", "approved"],
         "defaults": {
@@ -325,26 +325,15 @@ def add_issue_to_project(gh: str, issue_node_id: str) -> str:
     return item_id
 
 
-def set_project_type_feature(gh: str, item_id: str) -> None:
-    query = """
-      mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
-        updateProjectV2ItemFieldValue(input: {
-          projectId: $projectId
-          itemId: $itemId
-          fieldId: $fieldId
-          value: { singleSelectOptionId: $optionId }
-        }) { projectV2Item { id } }
-      }
+def set_issue_type(gh: str, repository: str, issue_number: str, type_name: str) -> None:
+    """Set the native (root-level) GitHub issue type, e.g. Feature / Bug / Task.
+
+    This is the type shown on the issue itself and is distinct from any Project V2
+    board field. Requires the type to exist in the organisation's issue-type set.
     """
-    graphql(
-        gh,
-        query,
-        {
-            "projectId": PROJECT_ID,
-            "itemId": item_id,
-            "fieldId": TYPE_FIELD_ID,
-            "optionId": FEATURE_OPTION_ID,
-        },
+    run_command(
+        [gh, "api", "-X", "PATCH", f"repos/{repository}/issues/{issue_number}", "-f", f"type={type_name}"],
+        check=True,
     )
 
 
@@ -365,22 +354,23 @@ def apply_plan(target_arg: str, plan_path: str, *, dry_run: bool) -> dict[str, A
         "body_preview": normalized["body"],
         "label": normalized["label"],
         "assignee": normalized["assignee"],
-        "project": {"id": PROJECT_ID, "type": "Feature"},
+        "issue_type": ISSUE_TYPE,
+        "project": {"id": PROJECT_ID},
     }
     if dry_run:
-        return {**summary, "would_create_issue": True, "would_set_project_type": True}
+        return {**summary, "would_create_issue": True, "would_set_issue_type": ISSUE_TYPE, "would_add_to_project": True}
 
     issue = create_issue(gh, normalized)
+    set_issue_type(gh, normalized["repository"], issue["number"], ISSUE_TYPE)
     issue_node_id = get_issue_node_id(gh, normalized["repository"], issue["number"])
     project_item_id = add_issue_to_project(gh, issue_node_id)
-    set_project_type_feature(gh, project_item_id)
     return {
         **summary,
         "created_issue_url": issue["url"],
         "issue_number": issue["number"],
         "issue_node_id": issue_node_id,
         "project_item_id": project_item_id,
-        "project_type_set": "Feature",
+        "issue_type_set": ISSUE_TYPE,
     }
 
 


### PR DESCRIPTION
**What does this pull request change?**
The `raise-feature` and `raise-bug` skills now set the native GitHub issue type (root level, from the org issue-type set) on the issue itself, rather than writing the Sky Haven Project Board's custom *Type* single-select field. Issues are still added to the board. Removes the dead project-field code (`set_project_type_feature`, `TYPE_FIELD_ID`, `*_OPTION_ID`) and updates both SKILL.md files.

**Why?**
The board's custom Type field duplicated the native issue type, did not appear on the issue itself, and its option IDs regenerated whenever the field was edited — breaking hard-coded IDs. Setting the native issue type is the durable, root-level classification. The redundant board field has been removed.

**Related issue**
Relates to #27

**Checklist**

- [ ] No functional behaviour changed (type is now set at the issue root level, not the board)
- [x] No secrets or credentials included