### PR TITLE
[MINOR] - Add system-wide git skill guidance for Claude and Codex

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ Tracked in version control (enforced by `.gitignore`):
 | `claude/CLAUDE.md`                    | Claude Code         | Global Claude instructions installed to `~/.claude/CLAUDE.md`                                  |
 | `git/hooks/`                          | Git                 | Global git hooks (pre-commit, etc.)                                                            |
 | `codex/instructions.md`               | Codex CLI           | System prompt / custom instructions                                                            |
+| `codex/AGENTS.md`                     | Codex CLI           | Global agent guidance installed to `~/.codex/AGENTS.md`                                        |
 | `codex/config.toml`                   | Codex CLI           | Model, reasoning effort, options                                                               |
 | `vscode/settings.json`                | VS Code             | Editor and extension settings                                                                  |
 | `vscode/keybindings.json`             | VS Code             | Custom keyboard shortcuts                                                                      |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ Tracked in version control (enforced by `.gitignore`):
 | `claude/CLAUDE.md`                    | Claude Code         | Global Claude instructions installed to `~/.claude/CLAUDE.md`                                  |
 | `git/hooks/`                          | Git                 | Global git hooks (pre-commit, etc.)                                                            |
 | `codex/instructions.md`               | Codex CLI           | System prompt / custom instructions                                                            |
+| `codex/AGENTS.md`                     | Codex CLI           | Global agent guidance installed to `~/.codex/AGENTS.md`                                        |
 | `codex/config.toml`                   | Codex CLI           | Model, reasoning effort, options                                                               |
 | `vscode/settings.json`                | VS Code             | Editor and extension settings                                                                  |
 | `vscode/keybindings.json`             | VS Code             | Custom keyboard shortcuts                                                                      |

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -32,6 +32,28 @@ security, and simplicity, in that order.
   `terraform destroy` without explicit confirmation.
 - Prefer idempotent operations.
 
+## Git and work-item workflow
+
+Always use these skills for these operations — never raw `git commit`,
+`git push`, `gh pr create`, or direct issue creation:
+
+| Operation                                            | Skill             |
+| ---------------------------------------------------- | ----------------- |
+| Commit and push changes                              | `git-commit-push` |
+| Create a pull request                                | `create-pr`       |
+| Clean up git state (merged branches, prune remotes)  | `git-cleanup`     |
+| Raise a GitHub issue or other work item              | `raise-issue`     |
+
+Invocation: the user types the slash command (e.g. `/create-pr`); the agent
+invokes the Skill tool (e.g. `Skill` with `skill: "create-pr"`). Example:
+asked to "commit and push this", invoke `git-commit-push` — do not run
+`git commit` yourself.
+
+Scope: these skills are only for the mutating operations above. Read-only
+git inspection (`git status`, `git log`, `git diff`, `git blame`, branch
+listing) is normal tool use — do not invoke a skill for it. Never perform
+the mutating operations without the matching skill.
+
 ## Style
 
 - Terraform: 2-space indent, explicit provider versions, use `for_each` instead

--- a/codex/AGENTS.md
+++ b/codex/AGENTS.md
@@ -1,0 +1,28 @@
+# Codex Global Guidance
+
+This file is installed to `~/.codex/AGENTS.md` by
+`scripts/Install-DeveloperConfig.ps1`. Skills are installed under
+`~/.codex/skills/<name>/SKILL.md`.
+
+## Git and work-item workflow
+
+Always use these skills for these operations — never raw `git commit`,
+`git push`, `gh pr create`, or direct issue creation:
+
+| Operation                                            | Skill             |
+| ---------------------------------------------------- | ----------------- |
+| Commit and push changes                              | `git-commit-push` |
+| Create a pull request                                | `create-pr`       |
+| Clean up git state (merged branches, prune remotes)  | `git-cleanup`     |
+| Raise a GitHub issue or other work item              | `raise-issue`     |
+
+Invocation: the user types the skill name (e.g. `$create-pr`) or asks for it
+by name; the agent reads and follows `~/.codex/skills/<name>/SKILL.md`.
+Example: asked to "commit and push this", follow
+`~/.codex/skills/git-commit-push/SKILL.md` — do not run `git commit`
+yourself.
+
+Scope: these skills are only for the mutating operations above. Read-only
+git inspection (`git status`, `git log`, `git diff`, `git blame`, branch
+listing) is normal tool use — do not invoke a skill for it. Never perform
+the mutating operations without the matching skill.

--- a/scripts/Install-DeveloperConfig.ps1
+++ b/scripts/Install-DeveloperConfig.ps1
@@ -634,6 +634,7 @@ Merge-ClaudeSettings "$Repo\claude\settings.json" "$claude\settings.json"
 
 Write-Host "`nCodex" -ForegroundColor Cyan
 New-Symlink "$codex\instructions.md" "$Repo\codex\instructions.md"
+New-Symlink "$codex\AGENTS.md" "$Repo\codex\AGENTS.md"
 Merge-CodexConfig "$Repo\codex\config.toml" "$codex\config.toml"
 
 # -- VS Code ---------------------------------------------------------------


### PR DESCRIPTION
**What does this pull request change?**
- `claude/CLAUDE.md`: adds a "Git and work-item workflow" section mapping commit+push → `git-commit-push`, PR creation → `create-pr`, git cleanup → `git-cleanup`, and issue creation → `raise-issue`, with Claude invocation syntax (user-typed `/skill` and agent Skill-tool invocation) and an explicit scope statement excluding read-only git inspection.
- `codex/AGENTS.md` (new): the same mapping and scope statement with Codex-compatible invocation (`$skill-name` / by name, following `~/.codex/skills/<name>/SKILL.md`).
- `scripts/Install-DeveloperConfig.ps1`: installs `codex/AGENTS.md` to `~/.codex/AGENTS.md`, following the existing `instructions.md` symlink pattern.
- Root `CLAUDE.md` / `AGENTS.md`: tracked-paths tables gain the `codex/AGENTS.md` row.

**Why?**
Both Claude and Codex must be told system-wide to use the git workflow skills instead of raw `git`/`gh` commands, and only for those mutating operations. Codex CLI reads global guidance from `~/.codex/AGENTS.md` (`instructions.md` is legacy and stays wired via `model_instructions_file` in `config.toml`).

Verified on this machine: the installer distributed both files — `~/.claude/CLAUDE.md` contains the new section and `~/.codex/AGENTS.md` matches the repo source.

**Related issue**
Closes https://github.com/skyhaven-ltd/infra-developer-config/issues/32

**Checklist**

- [x] No functional behaviour changed
- [x] No secrets or credentials included

🤖 Generated with [Claude Code](https://claude.com/claude-code)